### PR TITLE
Rollback default kitchen suite's name

### DIFF
--- a/templates/.kitchen.yml.erb
+++ b/templates/.kitchen.yml.erb
@@ -7,6 +7,6 @@ platforms:
 - name: ubuntu-14.04
 
 suites:
-- name: <%= cookbook_name %>-default
+- name: default
   run_list:
   - recipe[<%= cookbook_name %>]


### PR DESCRIPTION
My last change cause a mismatch between the suite's name in kitchen
configuration file and the created directory `test/integration/default`

There was no reason to rename this suite's name, I think it's preferable
to rollback it instead of dynamically create suite's directory.